### PR TITLE
bump win-dpapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "keytar": "^5.0.0",
-    "win-dpapi": "^0.1.0"
+    "win-dpapi": "^1.1.0"
   }
 }


### PR DESCRIPTION
Fixes native build errors.  Exact diff: https://github.com/daguej/node-dpapi/compare/v0.1.0..v1.1.0